### PR TITLE
update building workflow to work on develop

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop ]
   pull_request:
-    branches: [ develop, master ]
+    branches: [ develop ]
 
 jobs:
   build:


### PR DESCRIPTION
This way the same build wont have to be triggered when pushing to master unnecessarily. Master also has the deployment workflow, so this will make things more clear.